### PR TITLE
add trial division generator

### DIFF
--- a/generator_test.go
+++ b/generator_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 )
 
-// 50 years of hourly postings, ignoring leap years
-const MAX_PRIMES = 50 * 365 * 24
+// 100 years of hourly postings, ignoring leap years
+const MAX_PRIMES = 100 * 365 * 24
 
 func TestGeneratorsIdentical(t *testing.T) {
 	ctx := context.Background()

--- a/generator_test.go
+++ b/generator_test.go
@@ -1,0 +1,43 @@
+package primebot
+
+import (
+	"context"
+	"testing"
+)
+
+// 50 years of hourly postings, ignoring leap years
+const MAX_PRIMES = 50 * 365 * 24
+
+func TestGeneratorsIdentical(t *testing.T) {
+	ctx := context.Background()
+
+	td := NewTrialDivisionGenerator(0)
+	pp := NewProbablyPrimeGenerator(0)
+
+	count := 0
+	for {
+		p1, err1 := td.Generate(ctx)
+		p2, err2 := pp.Generate(ctx)
+		if err1 != nil {
+			if err1 == err2 && err1 == ErrOverflow {
+				// success
+				return
+			}
+
+			t.Fatal(err1)
+		}
+		if err2 != nil {
+			t.Fatal(err2)
+		}
+
+		if p1 != p2 {
+			t.Errorf("got unequal primes; p1: %d, p2: %d", p1, p2)
+		}
+
+		count = count + 1
+		if count >= MAX_PRIMES {
+			// done
+			return
+		}
+	}
+}

--- a/generator_test.go
+++ b/generator_test.go
@@ -16,18 +16,13 @@ func TestGeneratorsIdentical(t *testing.T) {
 
 	count := 0
 	for {
-		p1, err1 := td.Generate(ctx)
-		p2, err2 := pp.Generate(ctx)
-		if err1 != nil {
-			if err1 == err2 && err1 == ErrOverflow {
-				// success
-				return
-			}
-
-			t.Fatal(err1)
+		p1, err := td.Generate(ctx)
+		if err != nil {
+			t.Fatal(err)
 		}
-		if err2 != nil {
-			t.Fatal(err2)
+		p2, err := pp.Generate(ctx)
+		if err != nil {
+			t.Fatal(err)
 		}
 
 		if p1 != p2 {
@@ -36,7 +31,7 @@ func TestGeneratorsIdentical(t *testing.T) {
 
 		count = count + 1
 		if count >= MAX_PRIMES {
-			// done
+			// successfully reached count of equal primes
 			return
 		}
 	}

--- a/generator_trialdivision.go
+++ b/generator_trialdivision.go
@@ -11,11 +11,13 @@ func NewTrialDivisionGenerator(start uint64) *TrialDivisionGenerator {
 	cur.SetUint64(start)
 	zero := big.NewInt(0)
 	one := big.NewInt(1)
+	two := big.NewInt(2)
 
 	return &TrialDivisionGenerator{
 		cur:   cur,
 		zero:  zero,
 		one:   one,
+		two:   two,
 		mutex: &sync.Mutex{},
 	}
 }
@@ -24,6 +26,7 @@ type TrialDivisionGenerator struct {
 	cur   *big.Int
 	zero  *big.Int
 	one   *big.Int
+	two   *big.Int
 	mutex *sync.Mutex
 }
 
@@ -63,6 +66,7 @@ func (t *TrialDivisionGenerator) Generate(ctx context.Context) (uint64, error) {
 			}
 
 			trial.SetUint64(2)
+			first := true
 			max.Sqrt(t.cur)
 
 		OUTER:
@@ -77,7 +81,12 @@ func (t *TrialDivisionGenerator) Generate(ctx context.Context) (uint64, error) {
 					if mod.Mod(t.cur, trial).Cmp(t.zero) == 0 {
 						break OUTER
 					}
-					trial.Add(trial, t.one)
+					if first {
+						trial.Add(trial, t.one)
+						first = false
+					} else {
+						trial.Add(trial, t.two)
+					}
 				}
 			}
 

--- a/generator_trialdivision.go
+++ b/generator_trialdivision.go
@@ -1,0 +1,87 @@
+package primebot
+
+import (
+	"context"
+	"math/big"
+	"sync"
+)
+
+func NewTrialDivisionGenerator(start uint64) *TrialDivisionGenerator {
+	cur := &big.Int{}
+	cur.SetUint64(start)
+	zero := big.NewInt(0)
+	one := big.NewInt(1)
+
+	return &TrialDivisionGenerator{
+		cur:   cur,
+		zero:  zero,
+		one:   one,
+		mutex: &sync.Mutex{},
+	}
+}
+
+type TrialDivisionGenerator struct {
+	cur   *big.Int
+	zero  *big.Int
+	one   *big.Int
+	mutex *sync.Mutex
+}
+
+func (t *TrialDivisionGenerator) SetStart(start uint64) {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	cur := &big.Int{}
+	cur.SetUint64(start)
+	t.cur = cur
+}
+
+func (t *TrialDivisionGenerator) Generate(ctx context.Context) (uint64, error) {
+	trial := big.NewInt(2)
+	mod := &big.Int{}
+	max := &big.Int{}
+
+	defer t.cur.Add(t.cur, t.one)
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	// handle == 2
+	if t.cur.Cmp(trial) == 0 {
+		return t.cur.Uint64(), nil
+	}
+	// handle < 2
+	if t.cur.Cmp(trial) < 0 {
+		t.cur.Set(trial)
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return 0, ErrCanceled
+		default:
+			if !t.cur.IsUint64() {
+				return 0, ErrOverflow
+			}
+
+			trial.SetUint64(2)
+			max.Sqrt(t.cur)
+
+		OUTER:
+			for {
+				select {
+				case <-ctx.Done():
+					return 0, ErrCanceled
+				default:
+					if trial.Cmp(max) > 0 {
+						return t.cur.Uint64(), nil
+					}
+					if mod.Mod(t.cur, trial).Cmp(t.zero) == 0 {
+						break OUTER
+					}
+					trial.Add(trial, t.one)
+				}
+			}
+
+			t.cur.Add(t.cur, t.one)
+		}
+	}
+}

--- a/generator_trialdivision_test.go
+++ b/generator_trialdivision_test.go
@@ -1,0 +1,54 @@
+package primebot
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTrialDivisionGenerator(t *testing.T) {
+	ctx := context.Background()
+	cases := map[uint64][]uint64{
+		0: {2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31},
+		7: {7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43},
+		6: {7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43},
+	}
+
+	for start, expected := range cases {
+		g := NewTrialDivisionGenerator(start)
+		for _, ex := range expected {
+			p, err := g.Generate(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if p != ex {
+				t.Errorf("expected equal primes, got %v, wanted %v", p, ex)
+			}
+		}
+	}
+}
+
+func TestTrialDivisionGeneratorCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	start := uint64(1 << 32)
+
+	g := NewTrialDivisionGenerator(start)
+	go func() {
+		_, err := g.Generate(ctx)
+		if err != ErrCanceled {
+			t.Errorf("expected cancellation error, got %v", err)
+		}
+	}()
+	cancel()
+}
+
+func TestTrialDivisionGeneratorOverflow(t *testing.T) {
+	ctx := context.Background()
+	start := uint64((1 << 64) - 1)
+
+	g := NewTrialDivisionGenerator(start)
+	n, err := g.Generate(ctx)
+	if err != ErrOverflow {
+		t.Errorf("expected overflow error, got %v, %v", n, err)
+	}
+}

--- a/interval_test.go
+++ b/interval_test.go
@@ -15,7 +15,7 @@ func TestIntervalTicker(t *testing.T) {
 	c := it.Start(ctx, 1*time.Second)
 
 	tc := <-c
-	if s := tc.Sub(now).Seconds(); s > 1.1 || s < 0.9 {
+	if s := tc.Sub(now).Seconds(); s > 1.2 || s < 0.8 {
 		t.Errorf("expected first tick at ~1 seconds, saw %v", s)
 	}
 
@@ -26,7 +26,7 @@ func TestIntervalTicker(t *testing.T) {
 		}
 		now = time.Now()
 		tc = <-c
-		if s := tc.Sub(now).Seconds(); s > 2.1 || s < 1.9 {
+		if s := tc.Sub(now).Seconds(); s > 2.2 || s < 1.8 {
 			t.Errorf("expected tick at ~2 seconds, saw %v", s)
 		}
 		count--


### PR DESCRIPTION
adds a trial division generator, for a few (stupid?) reasons:

* according to [go docs](https://pkg.go.dev/math/big#Int.ProbablyPrime), `ProbablyPrime` is 100% accurate for inputs less than 2⁶⁴. That's true, but now there's a test that proves it for at least 100 years worth of primes, why not
* the _real_ reason is that it will let me refactor to support generating numbers that are larger than 2⁶⁴, a thing which will literally never happen, but what if it did?

This will be merged, and then that refactor will be done along with a composite generator that uses `ProbablyPrime` for inputs < 2⁶⁴, and trial division for those greater. Which we'll never need because we'll all be well dead before the bots reach there.