### PR TITLE
fix cancelling context too early

### DIFF
--- a/primebot.go
+++ b/primebot.go
@@ -60,8 +60,8 @@ func (p *PrimeBot) Start(ctx context.Context) error {
 		context.Background(),
 		p.opts.ServiceTimeout,
 	)
-	cancel() // cancel to avoid leaking
 	cur, err := p.ftc.Fetch(fetchctx)
+	cancel() // cancel to avoid leaking
 	if err != nil {
 		return err
 	}

--- a/primebot.go
+++ b/primebot.go
@@ -57,7 +57,7 @@ func (p *PrimeBot) Start(ctx context.Context) error {
 	p.log.Print("fetching initial list of statuses")
 
 	fetchctx, cancel := context.WithTimeout(
-		context.Background(),
+		ctx,
 		p.opts.ServiceTimeout,
 	)
 	cur, err := p.ftc.Fetch(fetchctx)
@@ -90,7 +90,7 @@ func (p *PrimeBot) Start(ctx context.Context) error {
 		case <-t:
 			status := <-pc
 			postctx, cancel := context.WithTimeout(
-				context.Background(),
+				ctx,
 				p.opts.ServiceTimeout,
 			)
 			err := p.pst.Post(postctx, status)


### PR DESCRIPTION
* fixes an issue where a context needed to be canceled to prevent leaking, but was done too early
* fix places that should've been using the parent context, but were creating their own new contexts